### PR TITLE
Correct the xschemrc syntax

### DIFF
--- a/xschem/xschemrc
+++ b/xschem/xschemrc
@@ -24,7 +24,7 @@ if {![info exists PDK]} {
 append XSCHEM_LIBRARY_PATH :[file dirname [info script]]
 
 # Source the dependencies xschemrc files
-foreach rcfile [glob -nocomplain ../ip/*/xschem/xschemrc] {
+foreach rcfile [glob -nocomplain [file dirname [info script]]/../ip/*/xschem/xschemrc] {
   puts "sourcing $rcfile"
   source $rcfile
 }


### PR DESCRIPTION
Correcting the xschemrc syntax so that xschem does not go into an infinite loop reading xschemrc files when the ADC is used as a submodule to another project (e.g., frigate_analog).